### PR TITLE
feat(resolver): add support for minitest

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	let document = editor.document;
-  let fileName: string = document.fileName;
+	let fileName: string = document.fileName;
 	let related: string = resolver.getRelated(fileName);
 	let relative: string = vscode.workspace.asRelativePath(related);
 	let fileExists: boolean = fs.existsSync(related);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,12 +42,12 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	let document = editor.document;
-	let fileName: string = document.fileName;
+  let fileName: string = document.fileName;
 	let related: string = resolver.getRelated(fileName);
 	let relative: string = vscode.workspace.asRelativePath(related);
 	let fileExists: boolean = fs.existsSync(related);
 	let dirname: string = path.dirname(related);
-	
+
 	//console.log('fileExists', fileExists);
 
 	if (fileExists) {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1,77 +1,91 @@
 //import * as assert from 'assert';
-import test from 'ava';
+import test from "ava";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-//import * as vscode from 'vscode';
-import * as resolver from './resolver';
+import * as vscode from "vscode";
+import * as resolver from "./resolver";
 
-var testCases = [
-	[
-		'/spec/something/foo_spec.rb',
-		'/app/something/foo.rb',
-	],
-	[
-		'/spec/views/namespace/users/_something.html.erb_spec.rb',
-		'/app/views/namespace/users/_something.html.erb',
-	],
-	[
-		'/spec/views/namespace/users/something.html.haml_spec.rb',
-		'/app/views/namespace/users/something.html.haml',
-	],
-	[
-		'/spec/lib/something/foo_spec.rb',
-		'/lib/something/foo.rb',
-	],
-]
+var testCases = {
+  spec: [
+    ["/spec/something/foo_spec.rb", "/app/something/foo.rb"],
+    [
+      "/spec/views/namespace/users/_something.html.erb_spec.rb",
+      "/app/views/namespace/users/_something.html.erb"
+    ],
+    [
+      "/spec/views/namespace/users/something.html.haml_spec.rb",
+      "/app/views/namespace/users/something.html.haml"
+    ],
+    ["/spec/lib/something/foo_spec.rb", "/lib/something/foo.rb"],
+  ],
+  test: [
+    ["/test/something/foo_test.rb", "/app/something/foo.rb"],
+    [
+      "/test/views/namespace/users/_something.html.erb_test.rb",
+      "/app/views/namespace/users/_something.html.erb"
+    ],
+    [
+      "/test/views/namespace/users/something.html.haml_test.rb",
+      "/app/views/namespace/users/something.html.haml"
+    ],
+    ["/test/lib/something/foo_test.rb", "/lib/something/foo.rb"]
+  ]
+};
 
-test("isSpec", (t) => {
-	var testCases = [
-		[
-			'/spec/foo/something_spec.rb',
-			true,
-		],
-		[
-			'/spec/views/something.html.erb_spec.rb',
-			true,
-		],
-		[
-			'/app/foo/something.rb',
-			false,
-		],
-		[
-			'/spec/views/something.html.erb.rb',
-			false,
-		]
-	]
-	t.plan(testCases.length);
+test("isSpec", t => {
+  var testCases = [
+    ["/spec/foo/something_spec.rb", true],
+    ["/spec/views/something.html.erb_spec.rb", true],
+    ["/app/foo/something.rb", false],
+    ["/spec/views/something.html.erb.rb", false],
+    ["/test/foo/something_test.rb", true],
+    ["/test/views/something.html.erb_test.rb", true],
+    ["/test/views/something.html.erb.rb", false]
+  ];
+  t.plan(testCases.length);
 
-	testCases.forEach(function(testCase) {
-		var file = testCase[0];
-		var expected = testCase[1];
-		var res = resolver.isSpec(file);
-		t.is(res, expected);
-	});
+  testCases.forEach(function(testCase) {
+    var file = testCase[0];
+    var expected = testCase[1];
+    var res = resolver.isSpec(file);
+    t.is(res, expected);
+  });
 });
 
-test("specToCode", (t) => {
-	t.plan(testCases.length);
+test("specToCode", t => {
+  t.plan(testCases.spec.length + testCases.test.length);
 
-	testCases.forEach(function(testCase) {
-		var file = testCase[0];
-		var expected = testCase[1];
-		var res = resolver.specToCode(file);
-		t.is(res, expected);
-	});
+  testCases.spec.forEach(function(testCase) {
+    var file = testCase[0];
+    var expected = testCase[1];
+    var res = resolver.specToCode(file);
+    t.is(res, expected);
+  });
+
+  testCases.test.forEach(function(testCase) {
+    var file = testCase[0];
+    var expected = testCase[1];
+    var res = resolver.specToCode(file);
+    t.is(res, expected);
+  });
 });
 
-test("codeToSpec", (t) => {
-	t.plan(testCases.length);
+test("codeToSpec", t => {
+  t.plan(testCases.spec.length + testCases.test.length);
 
-	testCases.forEach(function(testCase) {
-		var file = testCase[1];
-		var expected = testCase[0];
-		var res = resolver.codeToSpec(file);
-		t.is(res, expected);
-	});
+  // TODO: tried pulling in Sinon to stub resolver._specDirExists(), but kept getting "cannont find module sinon"
+  testCases.spec.forEach(function(testCase) {
+    var file = testCase[1];
+    var expected = testCase[0];
+    var res = resolver.codeToSpec(file);
+    t.is(res, expected);
+  });
+
+  testCases.test.forEach(function(testCase) {
+    var file = testCase[1];
+    var expected = testCase[0];
+    var res = resolver.codeToSpec(file);
+    t.is(res, expected);
+  });
 });

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,3 +1,6 @@
+import * as path from "path";
+import * as fs from "fs";
+
 export function getRelated(file) {
 	if (isSpec(file)) {
 		return specToCode(file);
@@ -7,49 +10,63 @@ export function getRelated(file) {
 }
 
 export function isSpec(file) {
-	return file.indexOf('_spec.rb') > -1;
+	return file.indexOf('_spec.rb') > -1 || file.indexOf('_test.rb') > -1;
+}
+
+function _specDirExists() {
+	try {
+		fs.statSync(path.resolve("./spec")).isDirectory();
+	} catch (e) {
+		if (e.code === 'ENOENT') {
+      return false;
+    } else {
+      throw e;
+    }
+	}
 }
 
 export function codeToSpec(file) {
-	var viewRegex = /erb$|haml$|slim$/
+	var specType = _specDirExists() ? "spec" : "test";
+
+	var viewRegex = /erb$|haml$|slim$/;
 	var isViewFile = file.match(viewRegex);
-	
+
 	if (isViewFile) {
 		return file
-			.replace('/app/', '/spec/')
-			.replace('.haml', '.haml_spec.rb')
-			.replace('.erb', '.erb_spec.rb')
-			.replace('.slim', '.slim_spec.rb');
+			.replace('/app/', `/${specType}/`)
+			.replace('.haml', `.haml_${specType}.rb`)
+			.replace('.erb', `.erb_${specType}.rb`)
+			.replace('.slim', `.slim_${specType}.rb`);
 	}
-	
-	file = file.replace('.rb', '_spec.rb');
-	
+
+	file = file.replace('.rb', `_${specType}.rb`);
+
 	var isLibFile = file.indexOf('/lib/') > -1;
 	if (isLibFile) {
-		return file.replace('/lib/', '/spec/lib/');
+		return file.replace('/lib/', `/${specType}/lib/`);
 	}
-	
-	return file.replace('/app/', '/spec/');
+
+	return file.replace('/app/', `/${specType}/`);
 }
 
 export function specToCode(file: string) {
+	var specType = file.match(/(spec|test).rb$/)[1];
 
-	var viewRegex = /(.erb|.haml|.slim)_spec.rb$/;
-	
+	var viewRegex = /(.erb|.haml|.slim)_(spec|test).rb$/;
 	var isViewFile = file.match(viewRegex);
 	if (isViewFile) {
 		return file
-			.replace('_spec.rb', '')
-			.replace('/spec', '/app');
+			.replace(`_${specType}.rb`, '')
+			.replace(`/${specType}`, '/app');
 	}
 
-	file = file.replace('_spec.rb', '.rb');
+	file = file.replace(`_${specType}.rb`, '.rb');
 
-	var isLibFile = file.indexOf('/spec/lib/') > -1;
+	var isLibFile = file.indexOf(`/${specType}/lib/`) > -1;
 	if (isLibFile) {
-		return file.replace('/spec/lib/', '/lib/');
+		   return file.replace(`/${specType}/lib/`, '/lib/');
 	}
 
-	return file.replace('/spec/', '/app/');
+	return file.replace(`/${specType}/`, '/app/');
 }
 


### PR DESCRIPTION
Wouldn't it be great if this extension supported Minitest, too? You bet it would! 🎉 

Here's how:

- `isSpec()` is easy enough to get working by checking for `indexOf('_test.rb')`.
- `specToCode()` is a little more tricky, but we can check for a regex match to get what we need.
- `codeToSpec()` requires a little more work, but we can check if the `spec` directory exists to get what we need.

**NOTE**: I tried to pull in Sinon.js to stub `_specDirExists()`, but `npm run comile` kept barking about "cannot find module sinon". After a fair bit of googling, I'm not sure how to solve this. Any ideas are appreciated. :smile: Unfortunately, because I can't stub `_specDirExists()`, tests aren't passing. ☹️ 