### PR TITLE
Jump from controller to request spec if no controller spec found

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,8 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
 	if (fileExists) {
 		openFile(related);
 	} else if (resolver.isControllersOrRequests(fileName)) {
-		fileName = resolver.convertControllersOrRequestsPath(fileName)
-		related = resolver.getRelated(fileName);
+		related = resolver.getControllersRelated(fileName);
 		fs.existsSync(related) ? openFile(related) : openPrompt(related);
 	} else {
 		openPrompt(related)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,8 +61,6 @@ export function activate(context: vscode.ExtensionContext) {
 	} else if (resolver.isControllersOrRequests(fileName)) {
 		fileName = resolver.convertControllersOrRequestsPath(fileName)
 		related = resolver.getRelated(fileName);
-		console.log(related);
-		console.log(fs.existsSync(related));
 		fs.existsSync(related) ? openFile(related) : openPrompt(related);
 	} else {
 		openPrompt(related)

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -92,19 +92,15 @@ test("isControllersOrRequests", (t) => {
 	});
 });
 
-test("convertControllersOrRequestsPath", (t) => {
+test("getControllersRelated", (t) => {
 	var testCases = [
 		[
-			'/spec/something/foo_spec.rb',
-			'/spec/something/foo_spec.rb',
-		],
-		[
 			'/app/controllers/something/something_controller.rb',
-			'/app/requests/something/something.rb',
+			'/spec/requests/something/something_spec.rb',
 		],
 		[
 			'/spec/requests/something/something_spec.rb',
-			'/spec/controllers/something/something_controller_spec.rb',
+			'/app/controllers/something/something_controller.rb',
 		],
 	];
 
@@ -113,7 +109,7 @@ test("convertControllersOrRequestsPath", (t) => {
 	testCases.forEach(function (testCase) {
 		var file = testCase[0];
 		var expected = testCase[1];
-		var res = resolver.convertControllersOrRequestsPath(file);
+		var res = resolver.getControllersRelated(file);
 		t.is(res, expected);
 	});
 });

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -54,6 +54,70 @@ test("isSpec", (t) => {
 	});
 });
 
+test("isControllersOrRequests", (t) => {
+	var testCases = [
+		[
+			'/spec/foo/something_spec.rb',
+			false,
+		],
+		[
+			'/spec/views/something.html.erb_spec.rb',
+			false,
+		],
+		[
+			'/app/foo/something.rb',
+			false,
+		],
+		[
+			'/spec/views/something.html.erb.rb',
+			false,
+		],
+		[
+			'/app/controllers/something_controller.rb',
+			true,
+		],
+		[
+			'/spec/requests/something_spec.rb',
+			true,
+		]
+
+	]
+	t.plan(testCases.length);
+
+	testCases.forEach(function (testCase) {
+		var file = testCase[0];
+		var expected = testCase[1];
+		var res = resolver.isControllersOrRequests(file);
+		t.is(res, expected);
+	});
+});
+
+test("convertControllersOrRequestsPath", (t) => {
+	var testCases = [
+		[
+			'/spec/something/foo_spec.rb',
+			'/spec/something/foo_spec.rb',
+		],
+		[
+			'/app/controllers/something/something_controller.rb',
+			'/app/requests/something/something.rb',
+		],
+		[
+			'/spec/requests/something/something_spec.rb',
+			'/spec/controllers/something/something_controller_spec.rb',
+		],
+	];
+
+	t.plan(testCases.length);
+
+	testCases.forEach(function (testCase) {
+		var file = testCase[0];
+		var expected = testCase[1];
+		var res = resolver.convertControllersOrRequestsPath(file);
+		t.is(res, expected);
+	});
+});
+
 test("specToCode", (t) => {
 	t.plan(testCases.length);
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -10,10 +10,28 @@ export function isSpec(file) {
 	return file.indexOf('_spec.rb') > -1;
 }
 
+export function isControllersOrRequests(file) {
+	return file.indexOf('app/controllers') > -1 || file.indexOf('spec/requests') > -1;
+}
+
+export function convertControllersOrRequestsPath(file) {
+	const isControllerFile = file.match('app/controllers');
+	if (isControllerFile) {
+		return file.replace('/app/controllers/', '/app/requests/').replace('_controller.rb', '.rb');
+	}
+
+	const isRequestSpecFile = file.match('spec/requests');
+	if (isRequestSpecFile) {
+		return file.replace('/spec/requests/', '/spec/controllers/').replace('_spec.rb', '_controller_spec.rb');
+	}
+
+	return file;
+}
+
 export function codeToSpec(file) {
 	var viewRegex = /erb$|haml$|slim$/
 	var isViewFile = file.match(viewRegex);
-	
+
 	if (isViewFile) {
 		return file
 			.replace('/app/', '/spec/')
@@ -21,21 +39,21 @@ export function codeToSpec(file) {
 			.replace('.erb', '.erb_spec.rb')
 			.replace('.slim', '.slim_spec.rb');
 	}
-	
+
 	file = file.replace('.rb', '_spec.rb');
-	
+
 	var isLibFile = file.indexOf('/lib/') > -1;
 	if (isLibFile) {
 		return file.replace('/lib/', '/spec/lib/');
 	}
-	
+
 	return file.replace('/app/', '/spec/');
 }
 
 export function specToCode(file: string) {
 
 	var viewRegex = /(.erb|.haml|.slim)_spec.rb$/;
-	
+
 	var isViewFile = file.match(viewRegex);
 	if (isViewFile) {
 		return file

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -8,11 +8,7 @@ export function getRelated(file) {
 
 export function getControllersRelated(file) {
 	file = convertControllersOrRequestsPath(file);
-	if (isSpec(file)) {
-		return specToCode(file);
-	} else {
-		return codeToSpec(file);
-	}
+	return getRelated(file);
 }
 
 export function isSpec(file) {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -6,6 +6,15 @@ export function getRelated(file) {
 	}
 }
 
+export function getControllersRelated(file) {
+	file = convertControllersOrRequestsPath(file);
+	if (isSpec(file)) {
+		return specToCode(file);
+	} else {
+		return codeToSpec(file);
+	}
+}
+
 export function isSpec(file) {
 	return file.indexOf('_spec.rb') > -1;
 }
@@ -14,7 +23,7 @@ export function isControllersOrRequests(file) {
 	return file.indexOf('app/controllers') > -1 || file.indexOf('spec/requests') > -1;
 }
 
-export function convertControllersOrRequestsPath(file) {
+function convertControllersOrRequestsPath(file) {
 	const isControllerFile = file.match('app/controllers');
 	if (isControllerFile) {
 		return file.replace('/app/controllers/', '/app/requests/').replace('_controller.rb', '.rb');


### PR DESCRIPTION
## Issue ticket
- https://github.com/sporto/rails-go-to-spec-vscode/issues/4

## changes
- Jump from controller to request spec if no controller spec found
- Same is true when jumping from a spec
- Add function test

## not changes
This project seems to have outdated dependencies. Especially the version of vscode was old and could not be installed with npm in my environment

I didn't update package.json to minimize changes. I can also make a PR for the packages update. Please tell me the policy of the project
